### PR TITLE
Testing improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,16 @@
-/sheets/
+# Settings and credentials
 **/credentials.json*
 /.env
 /.env.testing
+# Data files
+/sheets/
+# Logs
 /log/
+# 3rd-party packages
 /vendor/
+# Tests
 /tests/.phpunit.cache
 /.php-cs-fixer.cache
+/.php-cs-fixer.dist.php
 /tests/screenshots/
+/.phpunit.cache/

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,8 @@
           "Composer\\Config::disableProcessTimeout",
           "php -S 0.0.0.0:8000"
         ],
-        "test-e2e": "cd tests && ../vendor/bin/phpunit"
+        "test-all": "cd tests && ../vendor/bin/phpunit",
+        "test-e2e": "cd tests && ../vendor/bin/phpunit EndToEnd",
+        "test-integration": "cd tests && ../vendor/bin/phpunit Integration"
     }
 }

--- a/tests/EndToEnd/MapTest.php
+++ b/tests/EndToEnd/MapTest.php
@@ -11,7 +11,7 @@ use ZapSheets\Tests\helpers\TestHelper;
  */
 class MapTest extends TestHelper
 {
-    #[DependsExternal('PushTest', 'testPushAll')]
+    #[DependsExternal('ZapSheets\Tests\EndToEnd\PushTest', 'testPushAll')]
     public function testIndex(): void
     {
         $this->navigateTo('/?id=' . $_ENV['TEST_SPREADSHEET_ID']);
@@ -36,6 +36,6 @@ class MapTest extends TestHelper
 
         $this->assertStringContainsString("Admissions", $mapListText);
 
-        $this->takeScreenshot(getScreenshotPath(get_class($this) . '::MapTest'));
+        $this->takeScreenshot();
     }
 }

--- a/tests/EndToEnd/MapTest.php
+++ b/tests/EndToEnd/MapTest.php
@@ -1,9 +1,10 @@
 <?php
 
+namespace ZapSheets\Tests\EndToEnd;
+
 use PHPUnit\Framework\Attributes\DependsExternal;
 use Facebook\WebDriver\WebDriverBy;
-
-require_once __DIR__ . '/../helpers/TestHelper.php';
+use ZapSheets\Tests\helpers\TestHelper;
 
 /**
  * Test main application functionality
@@ -18,21 +19,21 @@ class MapTest extends TestHelper
         $this->waitForElement("#defaultScreen", 5 * 1000);
 
         $this->driver->wait(20)->until(
-            function($driver) {
+            function ($driver) {
                 $directoryContainer = $driver->findElements(WebDriverBy::id("directoryContainer"));
                 $spinningLoader = $driver->findElements(WebDriverBy::id("spinningLoader"));
                 $splashScreen = $driver->findElements(WebDriverBy::id("splashScreen"));
-                
-                return count($directoryContainer) > 0 && 
-                       $directoryContainer[0]->isDisplayed() &&
-                       (count($spinningLoader) === 0 || !$spinningLoader[0]->isDisplayed()) &&
-                       (count($splashScreen) === 0 || !$splashScreen[0]->isDisplayed());
-            }
+
+                return count($directoryContainer) > 0
+                       && $directoryContainer[0]->isDisplayed()
+                       && (count($spinningLoader) === 0 || !$spinningLoader[0]->isDisplayed())
+                       && (count($splashScreen) === 0 || !$splashScreen[0]->isDisplayed());
+            },
         );
 
         $mapListElement = $this->waitForElement("#mapListContainer", 20 * 1000);
         $mapListText = $mapListElement->getText();
-        
+
         $this->assertStringContainsString("Admissions", $mapListText);
 
         $this->takeScreenshot(getScreenshotPath(get_class($this) . '::MapTest'));

--- a/tests/EndToEnd/PushTest.php
+++ b/tests/EndToEnd/PushTest.php
@@ -52,6 +52,15 @@ class PushTest extends TestHelper
             'Cached background image hash does not match source',
         );
 
+        $pushStatusPath = $sheetDir . "/pushstatus.json";
+
+        $this->assertFileExists($pushStatusPath, 'pushstatus.json not found');
+
+        $this->assertSame(
+            file_get_contents($pushStatusPath),
+            '{"push":"true"}',
+        );
+
         $this->takeScreenshot();
     }
 }

--- a/tests/EndToEnd/PushTest.php
+++ b/tests/EndToEnd/PushTest.php
@@ -28,7 +28,29 @@ class PushTest extends TestHelper
             }
         );
 
-        $this->assertTrue(true);
+        $sheetDir = dirname(__DIR__, 2) . '/sheets/' . $_ENV['TEST_SPREADSHEET_ID'] . '/live';
+
+        $settings = json_decode(file_get_contents($sheetDir . '/settings.json'), true);
+        $bgImageUrl = null;
+        foreach ($settings as $setting) {
+            if ($setting['Name'] === 'BackgroundImage') {
+                $bgImageUrl = $setting['Value'];
+                break;
+            }
+        }
+        $this->assertNotEmpty($bgImageUrl, 'BackgroundImage URL not found in settings');
+
+        $bgCachePath = $sheetDir . '/cacheImages/bg.png';
+        $this->assertFileExists($bgCachePath, 'Cached background image not found');
+
+        $sourceContent = file_get_contents($bgImageUrl);
+        $this->assertNotEmpty($sourceContent, 'Failed to download BackgroundImage from source');
+
+        $this->assertSame(
+            sha1($sourceContent),
+            sha1_file($bgCachePath),
+            'Cached background image hash does not match source',
+        );
 
         $this->takeScreenshot();
     }

--- a/tests/EndToEnd/PushTest.php
+++ b/tests/EndToEnd/PushTest.php
@@ -1,6 +1,9 @@
 <?php
 
+namespace ZapSheets\Tests\EndToEnd;
+
 use Facebook\WebDriver\WebDriverBy;
+use ZapSheets\Tests\helpers\TestHelper;
 
 require_once __DIR__ . '/../helpers/TestHelper.php';
 
@@ -27,6 +30,6 @@ class PushTest extends TestHelper
 
         $this->assertTrue(true);
 
-        $this->takeScreenshot(getScreenshotPath(get_class($this) . '::PushTest'));
+        $this->takeScreenshot();
     }
 }

--- a/tests/Integration/SaveLogTest.php
+++ b/tests/Integration/SaveLogTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace ZapSheets\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+
+class SaveLogTest extends TestCase
+{
+    private string $spreadsheetId = 'test_savelog';
+    private string $sessionId;
+    private string $testServerUrl;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->sessionId = 'test-' . bin2hex(random_bytes(8));
+        $this->testServerUrl = getTestServerUrl();
+        $this->cleanupLogFile();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanupLogFile();
+        parent::tearDown();
+    }
+
+    public function testSaveLogCreatesExpectedJsonFile(): void
+    {
+        $postData = http_build_query([
+            'id' => $this->spreadsheetId,
+            'sheet_version' => '1.0',
+            'sheet_title' => 'Test Sheet',
+            'app_version' => '2.0',
+            'poll_time' => '2024-01-01 12:00:00',
+            'kiosk_location' => 'Test Room',
+            'session_uuId' => $this->sessionId,
+            'kiosk' => 'K1',
+            'memory_used' => '1.23 MB',
+        ]);
+
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'POST',
+                'header' => "Content-Type: application/x-www-form-urlencoded\r\n",
+                'content' => $postData,
+            ],
+        ]);
+
+        $response = file_get_contents(
+            $this->testServerUrl . '/saveLog.php',
+            false,
+            $context
+        );
+
+        $this->assertSame('log data saved', $response);
+
+        $logFilePath = dirname(__DIR__, 2) . '/log/' . $this->spreadsheetId . '/' . $this->sessionId . '.json';
+        $this->assertFileExists($logFilePath);
+
+        $logContent = json_decode(file_get_contents($logFilePath), true);
+        $this->assertIsArray($logContent);
+        $this->assertCount(1, $logContent);
+
+        $entry = $logContent[0];
+        $this->assertSame('2024-01-01 12:00:00', $entry['Poll On']);
+        $this->assertSame($this->spreadsheetId, $entry['Sheet Id']);
+        $this->assertSame('1.0', $entry['Sheet Version']);
+        $this->assertSame('Test Sheet', $entry['Sheet Title']);
+        $this->assertSame('2.0', $entry['App Version']);
+        $this->assertSame($this->sessionId, $entry['Device Session Id']);
+        $this->assertSame('K1', $entry['Kiosk']);
+        $this->assertSame('Test Room', $entry['Kiosk Location']);
+        $this->assertSame('1.23 MB', $entry['Momery Usage']);
+    }
+
+    private function cleanupLogFile(): void
+    {
+        $logDir = dirname(__DIR__, 2) . '/log/' . $this->spreadsheetId;
+        if (is_dir($logDir)) {
+            $this->deleteDirectory($logDir);
+        }
+    }
+
+    private function deleteDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                $this->deleteDirectory($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -62,7 +62,7 @@ if (!function_exists('getScreenshotPath')) {
 // Configure Selenium WebDriver options with geckodriver
 if (!defined('WEBDRIVER_BROWSER_OPTIONS')) {
     define('WEBDRIVER_BROWSER_OPTIONS', [
-        'headless' => false, // Set to false for debugging
+        'headless' => true, // Set to false for debugging
         'timeout' => 30000,
         'viewport' => ['width' => 1280, 'height' => 720],
         'browser' => 'firefox',

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -62,7 +62,7 @@ if (!function_exists('getScreenshotPath')) {
 // Configure Selenium WebDriver options with geckodriver
 if (!defined('WEBDRIVER_BROWSER_OPTIONS')) {
     define('WEBDRIVER_BROWSER_OPTIONS', [
-        'headless' => true, // Set to false for debugging
+        'headless' => false, // Set to false for debugging
         'timeout' => 30000,
         'viewport' => ['width' => 1280, 'height' => 720],
         'browser' => 'firefox',

--- a/tests/helpers/TestHelper.php
+++ b/tests/helpers/TestHelper.php
@@ -55,15 +55,22 @@ abstract class TestHelper extends TestCase
     protected function onNotSuccessfulTest(\Throwable $t): never
     {
         if ($this->driver) {
-            $this->takeScreenshot();
+            try {
+                $this->takeScreenshot();
+            } catch (\Throwable $e) {
+                fwrite(STDERR, "\nScreenshot capture failed: " . $e->getMessage() . "\n");
+            }
+            $this->driver->quit();
+            $this->driver = null;
         }
         parent::onNotSuccessfulTest($t);
     }
 
     protected function tearDown(): void
     {
-        if ($this->driver) {
+        if ($this->driver && $this->status()->isSuccess()) {
             $this->driver->quit();
+            $this->driver = null;
         }
 
         parent::tearDown();

--- a/tests/helpers/TestHelper.php
+++ b/tests/helpers/TestHelper.php
@@ -44,8 +44,8 @@ abstract class TestHelper extends TestCase
         $this->driver->manage()->window()->setSize(
             new \Facebook\WebDriver\WebDriverDimension(
                 $options['viewport']['width'],
-                $options['viewport']['height']
-            )
+                $options['viewport']['height'],
+            ),
         );
 
         // Set implicit wait
@@ -55,9 +55,7 @@ abstract class TestHelper extends TestCase
     protected function onNotSuccessfulTest(\Throwable $t): never
     {
         if ($this->driver) {
-            $screenshotPath = getScreenshotPath(get_class($this) . '::' . $this->name());
-            $this->driver->takeScreenshot($screenshotPath);
-            fwrite(STDERR, "\nScreenshot saved: $screenshotPath\n");
+            $this->takeScreenshot();
         }
         parent::onNotSuccessfulTest($t);
     }
@@ -87,7 +85,7 @@ abstract class TestHelper extends TestCase
     {
         $by = $this->getBySelector($selector);
         $this->driver->wait($timeout / 1000)->until(
-            WebDriverExpectedCondition::visibilityOfElementLocated($by)
+            WebDriverExpectedCondition::visibilityOfElementLocated($by),
         );
         return $this->driver->findElement($by);
     }
@@ -125,7 +123,7 @@ abstract class TestHelper extends TestCase
     protected function waitForPageLoad()
     {
         $this->driver->wait()->until(
-            WebDriverExpectedCondition::jsReturnsTrue("return document.readyState === 'complete'")
+            WebDriverExpectedCondition::jsReturnsTrue("return document.readyState === 'complete'"),
         );
     }
 
@@ -174,16 +172,16 @@ abstract class TestHelper extends TestCase
     {
         $by = $this->getBySelector($selector);
         $this->driver->wait($timeout / 1000)->until(
-            WebDriverExpectedCondition::invisibilityOfElementLocated($by)
+            WebDriverExpectedCondition::invisibilityOfElementLocated($by),
         );
     }
 
     /**
      * Take a screenshot
      */
-    protected function takeScreenshot($filename = null)
+    protected function takeScreenshot($filename = null): string
     {
-        $path = $filename ?: getScreenshotPath($this->name());
+        $path = $filename ?: getScreenshotPath(get_class($this) . '::' . $this->name());
         $this->driver->takeScreenshot($path);
         return $path;
     }

--- a/tests/helpers/TestHelper.php
+++ b/tests/helpers/TestHelper.php
@@ -52,16 +52,18 @@ abstract class TestHelper extends TestCase
         $this->driver->manage()->timeouts()->implicitlyWait(10);
     }
 
+    protected function onNotSuccessfulTest(\Throwable $t): never
+    {
+        if ($this->driver) {
+            $screenshotPath = getScreenshotPath(get_class($this) . '::' . $this->name());
+            $this->driver->takeScreenshot($screenshotPath);
+            fwrite(STDERR, "\nScreenshot saved: $screenshotPath\n");
+        }
+        parent::onNotSuccessfulTest($t);
+    }
+
     protected function tearDown(): void
     {
-        // Take screenshot on test failure
-        if (method_exists($this, 'getStatus') && $this->getStatus() === \PHPUnit\Runner\BaseTestRunner::STATUS_FAILURE) {
-            $screenshotPath = getScreenshotPath(get_class($this) . '::' . $this->getName());
-            $this->driver->takeScreenshot($screenshotPath);
-            echo "Screenshot saved to: $screenshotPath";
-        }
-
-        // Clean up WebDriver resources
         if ($this->driver) {
             $this->driver->quit();
         }
@@ -181,9 +183,8 @@ abstract class TestHelper extends TestCase
      */
     protected function takeScreenshot($filename = null)
     {
-        $path = $filename ?: getScreenshotPath(get_class($this) . '::' . $this->getName());
+        $path = $filename ?: getScreenshotPath($this->name());
         $this->driver->takeScreenshot($path);
         return $path;
     }
 }
-

--- a/tests/helpers/TestHelper.php
+++ b/tests/helpers/TestHelper.php
@@ -1,8 +1,9 @@
 <?php
 
+namespace ZapSheets\Tests\helpers;
+
 use PHPUnit\Framework\TestCase;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
-use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\WebDriverBy;
 use Facebook\WebDriver\WebDriverExpectedCondition;
 use Facebook\WebDriver\Firefox\FirefoxOptions;

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -13,6 +13,9 @@
         <testsuite name="EndToEnd">
             <directory>EndToEnd</directory>
         </testsuite>
+        <testsuite name="Integration">
+            <directory>Integration</directory>
+        </testsuite>
     </testsuites>
 
     <source>


### PR DESCRIPTION
Closes #18 

* New Integration test layer, used to test `saveLog.php`
* Check image download in `PushTest`
* Fix screenshot capture on failure

Test plan:

1. `composer server`
2. In another terminal: `composer test`
3. Verify that 3 tests are run (up from 2 previously)